### PR TITLE
Add BF configs for Zarr samples

### DIFF
--- a/data/64x64-fake-v0.1/.bioformats
+++ b/data/64x64-fake-v0.1/.bioformats
@@ -29,4 +29,3 @@ Tile_MD5 = c2f4b38ae94891f2e9a710b9cd93af77
 channel_count = 1
 header = 0.0.0.0.0 series_0 resolution_0
 resolution_count = 1
-

--- a/data/64x64-fake-v0.1/.bioformats
+++ b/data/64x64-fake-v0.1/.bioformats
@@ -1,0 +1,32 @@
+[0.0.0.0.0 global]
+access_ms = 68
+header = 0.0.0.0.0 global
+mem_mb = 8
+reader = ZarrReader
+series_count = 1
+test = true
+
+[0.0.0.0.0 series_0 resolution_0]
+ChannelName_0 = null
+Description = null
+DimensionOrder = XYCZT
+FalseColor = true
+Indexed = false
+Interleaved = false
+LittleEndian = false
+MD5 = c2f4b38ae94891f2e9a710b9cd93af77
+Name = 0/0
+PixelType = uint8
+RGB = false
+SizeC = 1
+SizeT = 1
+SizeX = 64
+SizeY = 64
+SizeZ = 1
+ThumbSizeX = 64
+ThumbSizeY = 64
+Tile_MD5 = c2f4b38ae94891f2e9a710b9cd93af77
+channel_count = 1
+header = 0.0.0.0.0 series_0 resolution_0
+resolution_count = 1
+

--- a/data/64x64-fake-v0.2/.bioformats
+++ b/data/64x64-fake-v0.2/.bioformats
@@ -1,0 +1,32 @@
+[0 global]
+access_ms = 61
+header = 0 global
+mem_mb = 12
+reader = ZarrReader
+series_count = 1
+test = true
+
+[0 series_0 resolution_0]
+ChannelName_0 = null
+Description = null
+DimensionOrder = XYCZT
+FalseColor = true
+Indexed = false
+Interleaved = false
+LittleEndian = false
+MD5 = c2f4b38ae94891f2e9a710b9cd93af77
+Name = 0/0
+PixelType = uint8
+RGB = false
+SizeC = 1
+SizeT = 1
+SizeX = 64
+SizeY = 64
+SizeZ = 1
+ThumbSizeX = 64
+ThumbSizeY = 64
+Tile_MD5 = c2f4b38ae94891f2e9a710b9cd93af77
+channel_count = 1
+header = 0 series_0 resolution_0
+resolution_count = 1
+

--- a/data/64x64-fake-v0.2/.bioformats
+++ b/data/64x64-fake-v0.2/.bioformats
@@ -29,4 +29,3 @@ Tile_MD5 = c2f4b38ae94891f2e9a710b9cd93af77
 channel_count = 1
 header = 0 series_0 resolution_0
 resolution_count = 1
-


### PR DESCRIPTION
This is to add configs for the 2 fake Zarr's to be used in the future with the Bio-Formats data repo tests.