### PR TITLE
Enable ZarrReader tests

### DIFF
--- a/scripts/zarr_reader_open
+++ b/scripts/zarr_reader_open
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+set -u
+
+
+test -e bftools || {
+    test -e bftools.zip || wget https://downloads.openmicroscopy.org/bio-formats/latest/artifacts/bftools.zip
+    unzip bftools
+}
+
+test -e ZarrReader  || git clone git://github.com/ome/ZarrReader 1>&2
+cd ZarrReader
+mvn package -DskipTests # 1>&2
+cd ..
+env BF_CP=ZarrReader/target/*.jar bftools/showinf -nopix "$@"

--- a/suites.yml
+++ b/suites.yml
@@ -7,3 +7,6 @@
 
 - name: checksum
   script: zarr_checksum
+
+- name: reader
+  script: zarr_reader_open


### PR DESCRIPTION
This script downloads the latest bftools.zip script,
checks out the latest ZarrReader code, builds it,
and launches the two together against each of the
sources defined.